### PR TITLE
Sprint 1: Add environment-backed application configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Runtime environment: development, testing, or production
+TWITCLONE_ENV=development
+
+# Required in production. Generate a long random value; never commit the real secret.
+SECRET_KEY=replace-with-a-random-secret
+
+# Optional. Defaults to a SQLite database in the repository directory.
+DATABASE_URL=sqlite:///twitter_clone.db
+
+# Optional. Defaults to static/uploads in the repository directory.
+UPLOAD_FOLDER=static/uploads
+
+# Background scheduled-post worker controls.
+SCHEDULER_ENABLED=true
+SCHEDULER_INTERVAL_SECONDS=60

--- a/application.py
+++ b/application.py
@@ -1,0 +1,26 @@
+"""Supported TwitClone application entry point.
+
+Use this module for local execution and WSGI deployment so environment-backed
+configuration is applied consistently while the legacy monolith is stabilized.
+"""
+
+from pathlib import Path
+
+from config import Config
+from app import app, scheduler
+
+
+app.config.from_object(Config)
+Path(app.config["UPLOAD_FOLDER"]).mkdir(parents=True, exist_ok=True)
+
+if not app.config["SCHEDULER_ENABLED"] and scheduler.running:
+    scheduler.shutdown(wait=False)
+
+application = app
+
+
+if __name__ == "__main__":
+    app.run(
+        debug=Config.ENVIRONMENT == "development",
+        port=int(__import__("os").getenv("PORT", "8000")),
+    )

--- a/config.py
+++ b/config.py
@@ -1,0 +1,51 @@
+"""Environment-backed configuration for TwitClone."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+BASE_DIR = Path(__file__).resolve().parent
+
+
+def _as_bool(value: str | None, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _database_uri() -> str:
+    configured = os.getenv("DATABASE_URL")
+    if configured:
+        return configured
+    return f"sqlite:///{BASE_DIR / 'twitter_clone.db'}"
+
+
+class Config:
+    """Base configuration shared by all environments."""
+
+    ENVIRONMENT = os.getenv("TWITCLONE_ENV", "development").strip().lower()
+    SECRET_KEY = os.getenv("SECRET_KEY")
+    SQLALCHEMY_DATABASE_URI = _database_uri()
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    UPLOAD_FOLDER = os.getenv("UPLOAD_FOLDER", str(BASE_DIR / "static" / "uploads"))
+    SCHEDULER_ENABLED = _as_bool(os.getenv("SCHEDULER_ENABLED"), default=True)
+    SCHEDULER_INTERVAL_SECONDS = int(os.getenv("SCHEDULER_INTERVAL_SECONDS", "60"))
+    TESTING = ENVIRONMENT == "testing"
+
+    @classmethod
+    def validate(cls) -> None:
+        """Fail clearly when production configuration is unsafe or incomplete."""
+
+        if cls.ENVIRONMENT == "production" and not cls.SECRET_KEY:
+            raise RuntimeError("SECRET_KEY is required when TWITCLONE_ENV=production")
+
+        if not cls.SECRET_KEY:
+            cls.SECRET_KEY = "development-only-change-me"
+
+        if cls.SCHEDULER_INTERVAL_SECONDS < 1:
+            raise RuntimeError("SCHEDULER_INTERVAL_SECONDS must be at least 1")
+
+
+Config.validate()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,68 @@
+# Application configuration
+
+TwitClone configuration is supplied through environment variables and loaded by `config.py`.
+
+## Supported entry point
+
+Run the application through `application.py` so the centralized configuration is applied:
+
+```bash
+python application.py
+```
+
+For a WSGI server, use `application:application`.
+
+The original `app.py` remains the legacy monolith during the stabilization sprints. New operational instructions should use the configured entry point above.
+
+## Local setup
+
+1. Copy `.env.example` to a local `.env` or export the variables through your shell or process manager.
+2. Replace the placeholder `SECRET_KEY` with a random value.
+3. Install development dependencies:
+
+   ```bash
+   python -m pip install -r requirements-dev.txt
+   ```
+
+4. Run configuration tests:
+
+   ```bash
+   python -m pytest tests/test_config.py
+   ```
+
+The project does not automatically parse `.env` yet. Export the variables or use a development tool that loads `.env` before starting Python. Automatic `.env` loading will be considered during dependency reconciliation rather than introducing an unreviewed dependency in this story.
+
+## Variables
+
+| Variable | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `TWITCLONE_ENV` | No | `development` | Selects development, testing, or production behavior. |
+| `SECRET_KEY` | Production only | Development-only fallback | Signs sessions and CSRF tokens. Production startup fails when absent. |
+| `DATABASE_URL` | No | Local SQLite database | SQLAlchemy database connection URL. |
+| `UPLOAD_FOLDER` | No | `static/uploads` | Location for uploaded post images. |
+| `SCHEDULER_ENABLED` | No | `true` | Enables or disables scheduled-post processing. |
+| `SCHEDULER_INTERVAL_SECONDS` | No | `60` | Scheduler polling interval; must be at least one second. |
+| `PORT` | No | `8000` | Port used by the local `application.py` runner. |
+
+## Environment guidance
+
+### Development
+
+Use a unique local secret where practical. The development fallback exists only to keep first-time setup simple and must never be treated as a deployment secret.
+
+### Testing
+
+Set `TWITCLONE_ENV=testing`, use an isolated database such as `sqlite:///:memory:`, and set `SCHEDULER_ENABLED=false`.
+
+### Production
+
+Set `TWITCLONE_ENV=production` and provide a strong `SECRET_KEY`. The application raises a clear startup error if the production secret is missing.
+
+Production processes should also supply an explicit database URL and upload location appropriate to the deployment platform.
+
+## Security notes
+
+- Never commit a real `.env` file or production secret.
+- Rotate any secret that has been exposed in source control or logs.
+- Use the hosting platform's secret manager or environment configuration for production values.
+- Do not run production using Flask's development server.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest>=8.0,<9.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,63 @@
+"""Tests for environment-backed configuration."""
+
+import importlib
+import sys
+
+import pytest
+
+
+def load_config(monkeypatch, **environment):
+    keys = {
+        "TWITCLONE_ENV",
+        "SECRET_KEY",
+        "DATABASE_URL",
+        "UPLOAD_FOLDER",
+        "SCHEDULER_ENABLED",
+        "SCHEDULER_INTERVAL_SECONDS",
+    }
+    for key in keys:
+        monkeypatch.delenv(key, raising=False)
+    for key, value in environment.items():
+        monkeypatch.setenv(key, value)
+
+    sys.modules.pop("config", None)
+    return importlib.import_module("config")
+
+
+def test_development_defaults_are_usable(monkeypatch):
+    config = load_config(monkeypatch)
+
+    assert config.Config.ENVIRONMENT == "development"
+    assert config.Config.SECRET_KEY == "development-only-change-me"
+    assert config.Config.SQLALCHEMY_DATABASE_URI.startswith("sqlite:///")
+    assert config.Config.SCHEDULER_ENABLED is True
+
+
+def test_environment_values_override_defaults(monkeypatch, tmp_path):
+    upload_folder = tmp_path / "uploads"
+    config = load_config(
+        monkeypatch,
+        TWITCLONE_ENV="testing",
+        SECRET_KEY="test-secret",
+        DATABASE_URL="sqlite:///:memory:",
+        UPLOAD_FOLDER=str(upload_folder),
+        SCHEDULER_ENABLED="false",
+        SCHEDULER_INTERVAL_SECONDS="15",
+    )
+
+    assert config.Config.TESTING is True
+    assert config.Config.SECRET_KEY == "test-secret"
+    assert config.Config.SQLALCHEMY_DATABASE_URI == "sqlite:///:memory:"
+    assert config.Config.UPLOAD_FOLDER == str(upload_folder)
+    assert config.Config.SCHEDULER_ENABLED is False
+    assert config.Config.SCHEDULER_INTERVAL_SECONDS == 15
+
+
+def test_production_requires_secret_key(monkeypatch):
+    with pytest.raises(RuntimeError, match="SECRET_KEY is required"):
+        load_config(monkeypatch, TWITCLONE_ENV="production")
+
+
+def test_scheduler_interval_must_be_positive(monkeypatch):
+    with pytest.raises(RuntimeError, match="must be at least 1"):
+        load_config(monkeypatch, SCHEDULER_INTERVAL_SECONDS="0")


### PR DESCRIPTION
## Sprint 1 story

Implements the first configuration-and-secrets slice for Issue #10.

## Changes

- Add centralized environment-backed configuration in `config.py`
- Require `SECRET_KEY` when running in production
- Add environment controls for the database, upload directory, scheduler enablement, and scheduler interval
- Add `application.py` as the supported configured local/WSGI entry point
- Create the upload directory when needed
- Allow the legacy scheduler to be disabled through configuration
- Add `.env.example` containing placeholders only
- Add focused configuration validation tests
- Add `requirements-dev.txt` for test tooling
- Add complete configuration and operational documentation

## Validation

The new configuration tests cover:

- development defaults
- environment overrides
- production startup failure without a secret
- scheduler interval validation

Automated execution is not yet available in the repository. Issue #13 will add CI, while Issue #11 will reconcile the full dependency set. The PR remains a draft until review confirms the interim configured-entry-point approach is acceptable.

## Important stabilization note

`app.py` remains the legacy monolith and currently initializes its original defaults before `application.py` applies centralized configuration. The supported execution path is now `python application.py` or WSGI target `application:application`. A later structural story will move initialization behind an application factory, eliminating this transitional ordering entirely.

## Documentation

See `docs/configuration.md` and `.env.example`.

## Scope control

No feature behavior, models, routes, templates, or unrelated UI were changed.

Related to #10.