### PR TITLE
Sprint 1: Add smoke tests and baseline CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Python 3.12 validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      TWITCLONE_ENV: testing
+      SECRET_KEY: ci-test-only-secret
+      DATABASE_URL: sqlite:///:memory:
+      UPLOAD_FOLDER: /tmp/twitclone-ci-uploads
+      SCHEDULER_ENABLED: "false"
+      SCHEDULER_INTERVAL_SECONDS: "60"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Verify dependency imports
+        run: python scripts/verify_dependencies.py
+
+      - name: Verify database migrations
+        run: python scripts/verify_migrations.py
+
+      - name: Run tests
+        run: python -m pytest --strict-markers --maxfail=1

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -1,0 +1,133 @@
+# Continuous Integration and Testing
+
+## Purpose
+
+TwitClone uses pytest and GitHub Actions to validate the minimum safe development baseline on every pull request and every push to `main`.
+
+The initial suite is intentionally small. It confirms that the application can be installed, configured, migrated, imported, and served without touching a developer database or starting the background scheduler.
+
+## Supported Runtime
+
+CI runs on Python 3.12, matching `.python-version`.
+
+## Local Setup
+
+Create and activate a virtual environment, then install development dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r requirements-dev.txt
+```
+
+On Windows PowerShell, activate with:
+
+```powershell
+.venv\Scripts\Activate.ps1
+```
+
+## Run the Full Validation Set
+
+Run the same logical checks used by CI:
+
+```bash
+python scripts/verify_dependencies.py
+python scripts/verify_migrations.py
+python -m pytest --strict-markers --maxfail=1
+```
+
+The pytest command alone is:
+
+```bash
+python -m pytest
+```
+
+## Test Isolation
+
+The test environment sets:
+
+- `TWITCLONE_ENV=testing`
+- a test-only secret
+- `DATABASE_URL=sqlite:///:memory:`
+- a temporary upload path
+- `SCHEDULER_ENABLED=false`
+
+The application tables are created in memory before each smoke test and removed afterward. Tests must never use the normal local SQLite database.
+
+## Current Smoke Coverage
+
+The baseline tests verify:
+
+- testing configuration is active
+- the database uses in-memory SQLite
+- the background scheduler is stopped
+- the public homepage returns HTTP 200
+- the login page returns HTTP 200
+- existing configuration validation tests continue to pass
+
+This is not comprehensive feature coverage. Authentication, posting, follows, messaging, polls, uploads, and scheduling need focused tests in later sprints.
+
+## GitHub Actions
+
+Workflow file:
+
+```text
+.github/workflows/ci.yml
+```
+
+Triggers:
+
+- every pull request
+- every push to `main`
+
+The workflow performs:
+
+1. repository checkout
+2. Python 3.12 setup
+3. dependency installation
+4. dependency import verification
+5. migration verification against disposable SQLite
+6. pytest execution
+
+The workflow uses read-only repository permissions and does not deploy infrastructure or access AWS.
+
+## Troubleshooting
+
+### Dependency installation fails
+
+Reproduce locally in a new virtual environment. Do not solve resolver failures by removing merged security pins without reviewing the originating advisory.
+
+### Dependency verification fails
+
+The verifier reports the import that failed. Confirm the relevant direct dependency remains in `requirements.txt` and is compatible with Python 3.12.
+
+### Migration verification fails
+
+Run:
+
+```bash
+python scripts/verify_migrations.py
+```
+
+Review the first failing Flask-Migrate or Alembic command. Do not repair an existing personal database while diagnosing the clean-database workflow.
+
+### Smoke test accesses a local database
+
+Confirm `tests/conftest.py` sets `DATABASE_URL` before importing `application`. Database configuration must be established before Flask-SQLAlchemy first creates its engine.
+
+### Scheduler remains active
+
+Confirm `SCHEDULER_ENABLED=false` is present before application import and that the test fixture shuts down any legacy scheduler instance. This is transitional until the application-factory refactor prevents scheduler startup at import time.
+
+### A bot PR changes the workflow
+
+Treat CI workflow changes as production-impacting. Review action versions, permissions, event triggers, and any newly introduced secrets before merging.
+
+## Branch Protection Recommendation
+
+After this workflow passes reliably on `main`, configure branch protection to require the `Python 3.12 validation` job before merging. Branch protection is a repository setting and is not changed by this PR.
+
+## AWS Relationship
+
+This CI workflow has no AWS cost. Future Terraform validation can be added without AWS credentials by running `terraform fmt -check` and `terraform validate`. Deployment workflows that can create billable resources must remain separate and require explicit approval.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+addopts = -ra
+python_files = test_*.py
+python_functions = test_*
+testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,48 @@
+"""Shared pytest fixtures for an isolated TwitClone test environment."""
+
+import os
+
+import pytest
+
+
+# These values must be set before importing the configured application because
+# Flask-SQLAlchemy reads the database URI when its engine is first accessed.
+os.environ.setdefault("TWITCLONE_ENV", "testing")
+os.environ.setdefault("SECRET_KEY", "test-only-secret")
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("UPLOAD_FOLDER", "/tmp/twitclone-test-uploads")
+os.environ.setdefault("SCHEDULER_ENABLED", "false")
+os.environ.setdefault("SCHEDULER_INTERVAL_SECONDS", "60")
+
+from application import application  # noqa: E402
+from app import db, scheduler  # noqa: E402
+
+
+@pytest.fixture()
+def app():
+    """Provide an application backed by an isolated in-memory database."""
+    application.config.update(
+        TESTING=True,
+        WTF_CSRF_ENABLED=False,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SCHEDULER_ENABLED=False,
+    )
+
+    if scheduler.running:
+        scheduler.shutdown(wait=False)
+
+    with application.app_context():
+        db.drop_all()
+        db.create_all()
+
+    yield application
+
+    with application.app_context():
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture()
+def client(app):
+    """Return Flask's test client for the isolated application."""
+    return app.test_client()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,24 @@
+"""Baseline smoke tests for configured TwitClone startup and public access."""
+
+from app import scheduler
+
+
+def test_application_uses_testing_configuration(app):
+    assert app.config["TESTING"] is True
+    assert app.config["SQLALCHEMY_DATABASE_URI"] == "sqlite:///:memory:"
+    assert app.config["SCHEDULER_ENABLED"] is False
+    assert scheduler.running is False
+
+
+def test_public_homepage_responds(client):
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert response.content_type.startswith("text/html")
+
+
+def test_login_page_responds(client):
+    response = client.get("/login")
+
+    assert response.status_code == 200
+    assert response.content_type.startswith("text/html")


### PR DESCRIPTION
## Sprint 1 story

Implements the smoke-test and GitHub Actions foundation for Issue #13.

## Changes

- Add an isolated pytest application fixture using in-memory SQLite
- Disable and verify the background scheduler during tests
- Add smoke tests for configured startup, the public homepage, and the login page
- Add baseline pytest configuration
- Add GitHub Actions CI for pull requests and pushes to `main`
- Run dependency verification, migration verification, and pytest in CI
- Add complete local testing, CI, troubleshooting, and branch-protection documentation

## CI environment

The workflow uses Python 3.12 and supplies test-only environment values:

- `TWITCLONE_ENV=testing`
- `DATABASE_URL=sqlite:///:memory:`
- `SCHEDULER_ENABLED=false`
- a test-only secret and upload directory

No AWS credentials are used and this workflow cannot create billable AWS resources.

## Validation sequence

```bash
python scripts/verify_dependencies.py
python scripts/verify_migrations.py
python -m pytest --strict-markers --maxfail=1
```

Opening this PR triggers the new workflow, providing the first clean GitHub-hosted execution of the combined dependency, migration, configuration, and route checks.

## Transitional note

The legacy monolith still starts its scheduler during `app.py` import. The configured application entry point and test fixture immediately shut it down when `SCHEDULER_ENABLED=false`. Preventing import-time startup entirely remains part of the later application-factory refactor.

## Scope control

No application routes, models, templates, features, dependency versions, UI, Terraform, or AWS resources were changed.

Closes #13.