### PR TITLE
Security: Require externally supplied Flask secret

### DIFF
--- a/config.py
+++ b/config.py
@@ -36,13 +36,13 @@ class Config:
 
     @classmethod
     def validate(cls) -> None:
-        """Fail clearly when production configuration is unsafe or incomplete."""
-
-        if cls.ENVIRONMENT == "production" and not cls.SECRET_KEY:
-            raise RuntimeError("SECRET_KEY is required when TWITCLONE_ENV=production")
+        """Fail clearly when required configuration is unsafe or incomplete."""
 
         if not cls.SECRET_KEY:
-            cls.SECRET_KEY = "development-only-change-me"
+            raise RuntimeError(
+                "SECRET_KEY is required for every TwitClone environment. "
+                "Set it outside source control before starting the application."
+            )
 
         if cls.SCHEDULER_INTERVAL_SECONDS < 1:
             raise RuntimeError("SCHEDULER_INTERVAL_SECONDS must be at least 1")

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,38 @@
+# Secret handling
+
+TwitClone must receive secrets from the runtime environment. Real secrets must never be committed to Git, copied into Terraform variables files, stored in images, or written into GitHub Actions workflow source.
+
+## Current required secret
+
+`SECRET_KEY` signs Flask sessions and CSRF tokens. It must be a long, random value and must be different between development, testing, and production.
+
+Generate a value locally with:
+
+```bash
+python -c "import secrets; print(secrets.token_urlsafe(64))"
+```
+
+Export it for a local shell session:
+
+```bash
+export SECRET_KEY='paste-generated-value-here'
+```
+
+For AWS deployment, the value will be supplied outside Terraform source and outside the repository. The final storage mechanism will be documented with the AWS architecture before deployment.
+
+## Rotation
+
+Changing `SECRET_KEY` invalidates existing signed sessions and CSRF tokens. Users will need to sign in again. Rotate immediately if a real production value is ever committed, logged, or otherwise exposed.
+
+## Values previously committed
+
+The repository contained two predictable placeholder values:
+
+- `your_secret_key` in the legacy `app.py` initialization path
+- `development-only-change-me` as the former development fallback in `config.py`
+
+Neither value should ever be used as a real secret. The environment-backed configuration now refuses to start without `SECRET_KEY`.
+
+## Transitional legacy note
+
+The supported entry point is `application.py`, which validates environment-backed configuration before exposing the WSGI application. The legacy monolith still contains its historical placeholder assignment and is tracked as an urgent removal item because changing that large file safely requires the CI-backed application-factory cleanup. Do not run `app.py` directly.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,13 +24,19 @@ def load_config(monkeypatch, **environment):
     return importlib.import_module("config")
 
 
-def test_development_defaults_are_usable(monkeypatch):
-    config = load_config(monkeypatch)
+def test_secret_key_is_required_in_development(monkeypatch):
+    with pytest.raises(RuntimeError, match="SECRET_KEY is required"):
+        load_config(monkeypatch, TWITCLONE_ENV="development")
 
-    assert config.Config.ENVIRONMENT == "development"
-    assert config.Config.SECRET_KEY == "development-only-change-me"
-    assert config.Config.SQLALCHEMY_DATABASE_URI.startswith("sqlite:///")
-    assert config.Config.SCHEDULER_ENABLED is True
+
+def test_secret_key_is_required_in_testing(monkeypatch):
+    with pytest.raises(RuntimeError, match="SECRET_KEY is required"):
+        load_config(monkeypatch, TWITCLONE_ENV="testing")
+
+
+def test_secret_key_is_required_in_production(monkeypatch):
+    with pytest.raises(RuntimeError, match="SECRET_KEY is required"):
+        load_config(monkeypatch, TWITCLONE_ENV="production")
 
 
 def test_environment_values_override_defaults(monkeypatch, tmp_path):
@@ -38,7 +44,7 @@ def test_environment_values_override_defaults(monkeypatch, tmp_path):
     config = load_config(
         monkeypatch,
         TWITCLONE_ENV="testing",
-        SECRET_KEY="test-secret",
+        SECRET_KEY="test-only-secret-not-for-production",
         DATABASE_URL="sqlite:///:memory:",
         UPLOAD_FOLDER=str(upload_folder),
         SCHEDULER_ENABLED="false",
@@ -46,18 +52,17 @@ def test_environment_values_override_defaults(monkeypatch, tmp_path):
     )
 
     assert config.Config.TESTING is True
-    assert config.Config.SECRET_KEY == "test-secret"
+    assert config.Config.SECRET_KEY == "test-only-secret-not-for-production"
     assert config.Config.SQLALCHEMY_DATABASE_URI == "sqlite:///:memory:"
     assert config.Config.UPLOAD_FOLDER == str(upload_folder)
     assert config.Config.SCHEDULER_ENABLED is False
     assert config.Config.SCHEDULER_INTERVAL_SECONDS == 15
 
 
-def test_production_requires_secret_key(monkeypatch):
-    with pytest.raises(RuntimeError, match="SECRET_KEY is required"):
-        load_config(monkeypatch, TWITCLONE_ENV="production")
-
-
 def test_scheduler_interval_must_be_positive(monkeypatch):
     with pytest.raises(RuntimeError, match="must be at least 1"):
-        load_config(monkeypatch, SCHEDULER_INTERVAL_SECONDS="0")
+        load_config(
+            monkeypatch,
+            SECRET_KEY="test-only-secret-not-for-production",
+            SCHEDULER_INTERVAL_SECONDS="0",
+        )


### PR DESCRIPTION
## Security priority

Removes the remaining environment-backed fallback secret and requires `SECRET_KEY` in development, testing, and production.

## Current committed values found

- `app.py`: `your_secret_key` — predictable legacy placeholder
- former `config.py` fallback: `development-only-change-me` — predictable development placeholder
- `.env.example`: `replace-with-a-random-secret` — intentional documentation placeholder, not a credential

No AWS access key, AWS secret key, API token, database password, or private key was found in the current-file audit.

## Changes

- Remove the `development-only-change-me` fallback from `config.py`
- Fail application configuration clearly whenever `SECRET_KEY` is absent
- Add tests covering missing keys in development, testing, and production
- Document secure generation, local injection, AWS handling, and rotation
- Create urgent Issue #29 to remove the historical assignment from the legacy monolith without risking unrelated feature regressions

## Important limitation

The large legacy `app.py` still contains `your_secret_key`. The supported `application.py` entry point validates external configuration first and replaces that value, so the supported runtime path cannot use it. However, complete source removal remains mandatory and is tracked as blocking Issue #29 before AWS deployment.

## Validation

```bash
SECRET_KEY=test-only-secret python -m pytest tests/test_config.py
```

The existing CI workflow supplies a test-only environment secret and should continue to run without repository or AWS credentials.

## Rotation guidance

If either placeholder was ever replaced locally with a real shared value or used in a public deployment, generate a new random key and invalidate existing sessions immediately.

Related to #10 and #29.