### PR TITLE
Sprint 2: Introduce application factory entry point

### DIFF
--- a/application.py
+++ b/application.py
@@ -1,26 +1,17 @@
-"""Supported TwitClone application entry point.
+"""Supported TwitClone application entry point."""
 
-Use this module for local execution and WSGI deployment so environment-backed
-configuration is applied consistently while the legacy monolith is stabilized.
-"""
-
-from pathlib import Path
+import os
 
 from config import Config
-from app import app, scheduler
+from twitclone import create_app
 
 
-app.config.from_object(Config)
-Path(app.config["UPLOAD_FOLDER"]).mkdir(parents=True, exist_ok=True)
-
-if not app.config["SCHEDULER_ENABLED"] and scheduler.running:
-    scheduler.shutdown(wait=False)
-
-application = app
+application = create_app()
+app = application
 
 
 if __name__ == "__main__":
-    app.run(
+    application.run(
         debug=Config.ENVIRONMENT == "development",
-        port=int(__import__("os").getenv("PORT", "8000")),
+        port=int(os.getenv("PORT", "8000")),
     )

--- a/docs/architecture/ADR-0006-application-factory.md
+++ b/docs/architecture/ADR-0006-application-factory.md
@@ -1,0 +1,61 @@
+# ADR-0006: Introduce a Transitional Application Factory
+
+- **Status:** Accepted
+- **Date:** 2026-07-23
+- **Sprint:** Sprint 2 — Architecture Modernization
+
+## Context
+
+TwitClone currently defines its Flask application, extensions, models, routes, and scheduler in the top-level `app.py` module. Configuration and tests have been improved, but the supported entry point still imports that global application directly.
+
+A conventional Flask package named `app` cannot safely be introduced while `app.py` exists because the module and package would compete for the same import name. Renaming and restructuring the entire monolith in one pull request would create unnecessary regression risk.
+
+## Decision
+
+Introduce a neutral `twitclone` package containing `create_app()`.
+
+For this first architecture slice, the factory:
+
+1. validates environment-backed configuration;
+2. lazily imports the existing legacy application;
+3. applies the validated configuration;
+4. creates the configured upload directory;
+5. disables the scheduler when configuration requires it; and
+6. returns the configured Flask application.
+
+`application.py` becomes a thin WSGI and local-development entry point that calls the factory.
+
+## Consequences
+
+### Positive
+
+- There is one documented application construction path.
+- WSGI deployment and tests use the same entry point.
+- Configuration validation occurs before the supported application is exposed.
+- Later refactors can move extensions, models, routes, and scheduler responsibilities behind the factory incrementally.
+- Existing endpoints, templates, models, and database migrations remain unchanged.
+
+### Transitional limitations
+
+- The factory currently returns the legacy application singleton rather than creating multiple independent Flask instances.
+- `app.py` still contains import-time initialization and scheduler behavior.
+- Complete application-factory isolation requires later Sprint 2 stories for extensions, scheduler, models, and blueprints.
+- The future package remains named `twitclone` unless and until the legacy `app.py` name is retired.
+
+## Alternatives considered
+
+### Rename `app.py` and create an `app/` package immediately
+
+Rejected for this story because it would require simultaneous route, template-root, extension, migration, and import changes across the full monolith.
+
+### Leave `application.py` as a configuration wrapper
+
+Rejected because it does not provide a stable construction API for tests, WSGI servers, and future modularization.
+
+## Follow-up work
+
+- Move extension objects into a dedicated module.
+- Eliminate scheduler import-time startup.
+- Move models behind the package boundary.
+- Convert route groups to blueprints.
+- Remove the legacy hard-coded secret assignment tracked by Issue #29.

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,0 +1,21 @@
+"""Smoke tests for the TwitClone application factory."""
+
+from application import application
+from twitclone import create_app
+
+
+def test_factory_returns_configured_application():
+    created = create_app()
+
+    assert created is application
+    assert created.config["SECRET_KEY"]
+    assert created.config["SQLALCHEMY_DATABASE_URI"]
+
+
+def test_factory_preserves_registered_routes():
+    created = create_app()
+    rules = {rule.rule for rule in created.url_map.iter_rules()}
+
+    assert "/" in rules
+    assert "/login" in rules
+    assert "/register" in rules

--- a/twitclone/__init__.py
+++ b/twitclone/__init__.py
@@ -1,0 +1,41 @@
+"""TwitClone application factory.
+
+This factory provides one supported construction path while the existing routes,
+models, and extensions remain in the legacy ``app.py`` module. Later Sprint 2
+stories will move those responsibilities into this package incrementally.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from flask import Flask
+
+from config import Config
+
+
+def create_app(config_object: type[Config] = Config) -> Flask:
+    """Create and configure the TwitClone Flask application.
+
+    The legacy module still owns route and model registration. Importing it only
+    after configuration validation ensures the supported startup path fails
+    before serving requests when required environment values are missing.
+    """
+
+    config_object.validate()
+
+    # Imported lazily so callers can establish environment variables before the
+    # legacy module and its Flask extensions are loaded.
+    from app import app as flask_app
+    from app import scheduler
+
+    flask_app.config.from_object(config_object)
+    Path(flask_app.config["UPLOAD_FOLDER"]).mkdir(parents=True, exist_ok=True)
+
+    if not flask_app.config["SCHEDULER_ENABLED"] and scheduler.running:
+        scheduler.shutdown(wait=False)
+
+    return flask_app
+
+
+__all__ = ["create_app"]


### PR DESCRIPTION
## Sprint 2 Story 2.1

Introduces the first application-factory boundary without moving routes, models, templates, or extensions.

## Changes

- Add `twitclone.create_app()` as the supported construction API
- Validate environment-backed configuration before exposing the application
- Lazily load the existing legacy application
- Centralize upload-directory preparation and scheduler-disable handling in the factory
- Reduce `application.py` to a thin WSGI/local entry point
- Add factory smoke tests covering configuration and preserved routes
- Add ADR-0006 documenting the incremental factory decision and limitations

## Architecture decision

The new package is named `twitclone` rather than `app` because the repository still contains `app.py`. Creating an `app/` package now would introduce an ambiguous import name and force a high-risk monolith rename in the same PR.

This factory is intentionally transitional: it returns the existing application singleton while later Sprint 2 stories move extensions, scheduler behavior, models, and routes behind the package boundary.

## Validation

CI should run:

```bash
python scripts/verify_dependencies.py
python scripts/verify_migrations.py
python -m pytest --strict-markers --maxfail=1
```

The new tests verify that:

- the factory returns the configured WSGI application
- required configuration is present
- existing `/`, `/login`, and `/register` routes remain registered

## Scope control

No route logic, models, templates, feature behavior, dependency versions, migrations, Terraform, AWS resources, or UI were changed.

## Known follow-up

Issue #29 remains the urgent source cleanup for the legacy `app.py` hard-coded placeholder. The supported factory path requires an externally supplied `SECRET_KEY`, but physical removal from the monolith is still blocking before AWS deployment.
