### PR TITLE
Security: Remove legacy hard-coded Flask secret

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,10 +16,13 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 import atexit
 
+from config import Config
+
+
+Config.validate()
 app = Flask(__name__)
-app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///twitter_clone.db'
-app.config['SECRET_KEY'] = 'your_secret_key'
-app.config['UPLOAD_FOLDER'] = 'static/uploads'  # Folder to store uploaded images
+app.config.from_object(Config)
+os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
 
 db = SQLAlchemy(app)
 migrate = Migrate(app, db)
@@ -36,16 +39,17 @@ def post_scheduled_tweets():
         db.session.commit()
 
 scheduler = BackgroundScheduler()
-scheduler.start()
-scheduler.add_job(
-    func=post_scheduled_tweets,
-    trigger=IntervalTrigger(seconds=60),  # Check every minute
-    id='post_scheduled_tweets',
-    name='Post scheduled tweets every minute',
-    replace_existing=True)
+if app.config['SCHEDULER_ENABLED']:
+    scheduler.add_job(
+        func=post_scheduled_tweets,
+        trigger=IntervalTrigger(seconds=app.config['SCHEDULER_INTERVAL_SECONDS']),
+        id='post_scheduled_tweets',
+        name='Post scheduled tweets',
+        replace_existing=True)
+    scheduler.start()
 
-# Shut down the scheduler when exiting the app
-atexit.register(lambda: scheduler.shutdown())
+    # Shut down the scheduler when exiting the app.
+    atexit.register(lambda: scheduler.shutdown() if scheduler.running else None)
 
 def gravatar(email, size=100, default='identicon', rating='g'):
     url = 'https://www.gravatar.com/avatar/'
@@ -557,6 +561,7 @@ def make_clickable_filter(text):
     return make_clickable_links(text)
 
 if __name__ == '__main__':
-    with app.app_context():
-        db.create_all()
-    app.run(debug=True, port=8000)
+    app.run(
+        debug=Config.ENVIRONMENT == 'development',
+        port=int(os.getenv('PORT', '8000')),
+    )

--- a/docs/security/legacy-secret-removal.md
+++ b/docs/security/legacy-secret-removal.md
@@ -1,0 +1,67 @@
+# Legacy Flask Secret Removal
+
+## Status
+
+The legacy `app.py` module no longer contains a hard-coded or fallback Flask signing key. All supported startup paths require `SECRET_KEY` to be supplied outside source control.
+
+## Why this matters
+
+Flask uses `SECRET_KEY` to sign session cookies and CSRF-related data. A predictable key allows an attacker to forge trusted client-side data. Placeholder values are therefore unsafe even when they were originally intended only for development.
+
+## Required local setup
+
+Generate a unique local key:
+
+```bash
+python -c "import secrets; print(secrets.token_urlsafe(64))"
+```
+
+Export it before running Flask, migrations, or tests outside the repository-provided test environment:
+
+```bash
+export SECRET_KEY='generated-value'
+```
+
+Do not add the generated value to `.env.example`, source files, test fixtures intended for production, shell history shared with others, or committed Terraform variables.
+
+## Startup behavior
+
+Both of these paths now require validated environment configuration:
+
+```bash
+python application.py
+```
+
+```bash
+python app.py
+```
+
+The supported path remains `application.py` / `application:application`. Direct `app.py` execution is retained only as a transitional compatibility path during Sprint 2.
+
+## Scheduler behavior
+
+The legacy scheduler starts only when:
+
+```bash
+SCHEDULER_ENABLED=true
+```
+
+Tests and multi-process web workers should set it to `false`. A later Sprint 2 story will move scheduler ownership out of the monolith entirely.
+
+## Rotation
+
+Rotate `SECRET_KEY` immediately if a real deployment ever used either historical placeholder value. Rotation invalidates existing signed sessions, so users will need to sign in again.
+
+## AWS deployment
+
+The AWS deployment must inject the value at runtime. Terraform must not place the plaintext value in committed files, plans, outputs, user-data logs, or repository variables. The final storage mechanism will be selected in the infrastructure sprint based on cost and operational simplicity.
+
+## Verification
+
+Run:
+
+```bash
+python -m pytest tests/test_config.py tests/test_legacy_security.py
+```
+
+The regression tests verify that known placeholder values are absent, direct import fails without an external key, and disabling the scheduler prevents background startup.

--- a/tests/test_legacy_security.py
+++ b/tests/test_legacy_security.py
@@ -1,0 +1,61 @@
+"""Security regression tests for the legacy application module."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_predictable_flask_secrets_are_absent_from_active_source():
+    """Known placeholder signing keys must never return to active source."""
+
+    active_source = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in (
+            REPOSITORY_ROOT / "app.py",
+            REPOSITORY_ROOT / "config.py",
+            REPOSITORY_ROOT / "application.py",
+            REPOSITORY_ROOT / "twitclone" / "__init__.py",
+        )
+    )
+
+    assert "your_secret_key" not in active_source
+    assert "development-only-change-me" not in active_source
+
+
+def test_direct_legacy_import_requires_external_secret_key():
+    """Importing app.py directly must fail clearly without SECRET_KEY."""
+
+    environment = os.environ.copy()
+    environment.pop("SECRET_KEY", None)
+    environment.update(
+        TWITCLONE_ENV="development",
+        DATABASE_URL="sqlite:///:memory:",
+        SCHEDULER_ENABLED="false",
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import app"],
+        cwd=REPOSITORY_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    output = f"{result.stdout}\n{result.stderr}"
+    assert result.returncode != 0
+    assert "SECRET_KEY is required" in output
+
+
+def test_scheduler_remains_stopped_when_disabled():
+    """The test environment must not start the legacy background scheduler."""
+
+    from app import scheduler
+
+    assert scheduler.running is False


### PR DESCRIPTION
## Security priority

Closes Issue #29 by removing the remaining predictable Flask signing key from the legacy monolith and making configuration authoritative before extension initialization.

## Changes

- Remove `your_secret_key` and all legacy inline Flask configuration from `app.py`
- Load and validate `Config` before SQLAlchemy, Flask-Migrate, Bcrypt, Flask-Login, and CSRF initialization
- Require an externally supplied `SECRET_KEY` for direct `app.py` imports and execution
- Create the configured upload directory during legacy initialization
- Start APScheduler only when `SCHEDULER_ENABLED=true`
- Use the configured scheduler interval rather than a hard-coded 60 seconds
- Remove automatic `db.create_all()` from direct startup; migrations remain authoritative
- Add regression tests for placeholder-secret absence, missing-key failure, and disabled scheduler behavior
- Add a security runbook covering generation, injection, rotation, scheduler behavior, and AWS requirements

## Validation

```bash
python scripts/verify_dependencies.py
python scripts/verify_migrations.py
python -m pytest --strict-markers --maxfail=1
```

Focused security validation:

```bash
python -m pytest tests/test_config.py tests/test_legacy_security.py
```

## Security outcome

- `your_secret_key` is no longer present in active source
- `development-only-change-me` remains absent
- No fallback Flask signing key exists
- Both supported and transitional startup paths fail clearly without `SECRET_KEY`
- Tests and multi-process runtimes can prevent scheduler startup with `SCHEDULER_ENABLED=false`

## Scope control

No models, routes, templates, user-facing features, dependency versions, migrations, UI, Terraform, or AWS resources were changed.

Closes #29.