### PR TITLE
Sprint 2: Add shared Flask extension import boundary

### DIFF
--- a/docs/architecture/ADR-0007-extension-import-boundary.md
+++ b/docs/architecture/ADR-0007-extension-import-boundary.md
@@ -1,0 +1,62 @@
+# ADR-0007: Introduce a stable Flask extension import boundary
+
+- Status: Accepted
+- Date: 2026-07-24
+
+## Context
+
+TwitClone currently defines and initializes SQLAlchemy, Flask-Migrate, Bcrypt,
+Flask-Login, and CSRF inside the legacy `app.py` monolith. Models, tests,
+migrations, and future blueprints need a stable place to import those objects
+before the monolith can be split safely.
+
+Moving the definitions and all dependent code in one change would create a
+large, difficult-to-review refactor. The repository also still relies on
+`app.py` for all models and routes.
+
+## Decision
+
+Add `twitclone/extensions.py` as the supported import boundary for shared Flask
+extensions.
+
+During the first slice, the module lazily returns the active objects initialized
+by `app.py`. This preserves object identity and avoids duplicate SQLAlchemy or
+Flask extension instances.
+
+New and migrated code should import extension objects from:
+
+```python
+from twitclone.extensions import db, migrate, bcrypt, login_manager, csrf
+```
+
+The next extension-refactor slice will move the unbound object definitions into
+`twitclone/extensions.py` and initialize them through the application lifecycle.
+Because callers already use the stable import path, that move will not require
+another broad import rewrite.
+
+## Consequences
+
+### Positive
+
+- Establishes one supported import location.
+- Preserves the exact extension objects currently used by models and migrations.
+- Reduces risk and review size for the eventual definition move.
+- Allows model and blueprint extraction to begin using package imports.
+
+### Temporary limitations
+
+- Importing an extension still loads the legacy `app.py` module.
+- Extension definitions and initialization remain in the monolith.
+- Multiple independent application instances are not yet supported.
+
+## Rejected alternative
+
+Move every extension definition and all dependent model, migration, fixture,
+and route imports in one PR. This was rejected because it would combine several
+Sprint 2 stories and make behavior regressions harder to isolate.
+
+## Validation
+
+Tests verify that every object imported through `twitclone.extensions` is the
+same object exported by the current application module and that SQLAlchemy is
+registered with the configured Flask application.

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1,0 +1,29 @@
+"""Regression tests for the shared Flask extension import boundary."""
+
+
+def test_shared_extension_imports_reference_active_objects():
+    import app as legacy_app
+    from twitclone.extensions import bcrypt, csrf, db, login_manager, migrate
+
+    assert db is legacy_app.db
+    assert migrate is legacy_app.migrate
+    assert bcrypt is legacy_app.bcrypt
+    assert login_manager is legacy_app.login_manager
+    assert csrf is legacy_app.csrf
+
+
+def test_database_extension_is_registered_with_application():
+    import app as legacy_app
+    from twitclone.extensions import db
+
+    assert "sqlalchemy" in legacy_app.app.extensions
+    assert legacy_app.app.extensions["sqlalchemy"] is not None
+    assert db.Model.metadata.tables
+
+
+def test_unknown_extension_name_fails_clearly():
+    import pytest
+    import twitclone.extensions as extensions
+
+    with pytest.raises(AttributeError, match="has no attribute"):
+        getattr(extensions, "unknown_extension")

--- a/twitclone/extensions.py
+++ b/twitclone/extensions.py
@@ -1,0 +1,39 @@
+"""Stable import boundary for TwitClone Flask extensions.
+
+This module is the supported import location for shared Flask extension objects.
+During the incremental monolith refactor, the objects are still initialized by
+``app.py``. Later Sprint 2 work will move their definitions here without
+requiring models, migrations, tests, and routes to change imports again.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_EXTENSION_NAMES = {
+    "db",
+    "migrate",
+    "bcrypt",
+    "login_manager",
+    "csrf",
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Return the extension object currently owned by the legacy module."""
+
+    if name not in _EXTENSION_NAMES:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    import app as legacy_app
+
+    return getattr(legacy_app, name)
+
+
+def __dir__() -> list[str]:
+    """Expose supported extension names to interactive tooling."""
+
+    return sorted(set(globals()) | _EXTENSION_NAMES)
+
+
+__all__ = sorted(_EXTENSION_NAMES)


### PR DESCRIPTION
## Sprint 2 Story 2.2 — first slice

Introduces a stable package import location for TwitClone's Flask extensions while preserving the exact objects currently initialized by the legacy monolith.

## Changes

- Add `twitclone/extensions.py` as the supported import boundary
- Lazily expose `db`, `migrate`, `bcrypt`, `login_manager`, and `csrf`
- Preserve object identity with the extensions currently used by models, routes, migrations, and tests
- Add tests for identity, SQLAlchemy registration, model metadata, and unknown names
- Add ADR-0007 documenting the phased extraction decision

## Why this is phased

`app.py` still owns all models and routes. Moving extension definitions, model imports, migration discovery, fixtures, and route dependencies in one PR would combine several architecture stories and produce a difficult-to-review monolith rewrite.

This first slice establishes the final import path:

```python
from twitclone.extensions import db, migrate, bcrypt, login_manager, csrf
```

The follow-up slice will move the unbound object definitions and initialization out of `app.py`. Callers using this boundary will not need another import rewrite.

## Validation

```bash
python scripts/verify_dependencies.py
python scripts/verify_migrations.py
python -m pytest --strict-markers --maxfail=1
```

Focused validation:

```bash
python -m pytest tests/test_extensions.py
```

## Scope control

No extension instance is duplicated. No routes, models, templates, scheduler behavior, database schema, dependencies, UI, Terraform, or AWS resources were changed.

Related to #46; does not close it until the definition move is complete.