### PR TITLE
Sprint 2: Move Flask extension ownership into package

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,11 +1,7 @@
 from PIL import Image
 import os
 from flask import Flask, render_template, redirect, url_for, request, flash, jsonify, send_from_directory
-from flask_sqlalchemy import SQLAlchemy
-from flask_bcrypt import Bcrypt
-from flask_login import LoginManager, UserMixin, login_user, login_required, logout_user, current_user
-from flask_migrate import Migrate
-from flask_wtf import CSRFProtect
+from flask_login import UserMixin, login_user, login_required, logout_user, current_user
 from werkzeug.utils import secure_filename
 import re
 from datetime import datetime, timedelta
@@ -17,19 +13,15 @@ from apscheduler.triggers.interval import IntervalTrigger
 import atexit
 
 from config import Config
+from twitclone.extensions import bcrypt, csrf, db, init_extensions, login_manager, migrate
 
 
 Config.validate()
 app = Flask(__name__)
 app.config.from_object(Config)
 os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+init_extensions(app)
 
-db = SQLAlchemy(app)
-migrate = Migrate(app, db)
-bcrypt = Bcrypt(app)
-login_manager = LoginManager(app)
-login_manager.login_view = 'login'
-csrf = CSRFProtect(app)
 
 def post_scheduled_tweets():
     now = datetime.utcnow()

--- a/docs/architecture/ADR-0007-extension-import-boundary.md
+++ b/docs/architecture/ADR-0007-extension-import-boundary.md
@@ -1,62 +1,72 @@
-# ADR-0007: Introduce a stable Flask extension import boundary
+# ADR-0007: Own Flask extensions in the application package
 
 - Status: Accepted
 - Date: 2026-07-24
 
 ## Context
 
-TwitClone currently defines and initializes SQLAlchemy, Flask-Migrate, Bcrypt,
+TwitClone originally defined and initialized SQLAlchemy, Flask-Migrate, Bcrypt,
 Flask-Login, and CSRF inside the legacy `app.py` monolith. Models, tests,
-migrations, and future blueprints need a stable place to import those objects
-before the monolith can be split safely.
+migrations, and future blueprints require one stable extension registry that does
+not depend on importing the monolith first.
 
-Moving the definitions and all dependent code in one change would create a
-large, difficult-to-review refactor. The repository also still relies on
-`app.py` for all models and routes.
+The first Story 2.2 slice established `twitclone.extensions` as a stable import
+boundary while retaining the original objects. That allowed the ownership move
+to happen separately from model and route extraction.
 
 ## Decision
 
-Add `twitclone/extensions.py` as the supported import boundary for shared Flask
-extensions.
-
-During the first slice, the module lazily returns the active objects initialized
-by `app.py`. This preserves object identity and avoids duplicate SQLAlchemy or
-Flask extension instances.
-
-New and migrated code should import extension objects from:
+`twitclone/extensions.py` owns one unbound instance of each Flask extension:
 
 ```python
 from twitclone.extensions import db, migrate, bcrypt, login_manager, csrf
 ```
 
-The next extension-refactor slice will move the unbound object definitions into
-`twitclone/extensions.py` and initialize them through the application lifecycle.
-Because callers already use the stable import path, that move will not require
-another broad import rewrite.
+The objects are created without a Flask application. After validated
+configuration is loaded, `init_extensions(app)` binds all five objects to the
+configured application.
+
+The legacy `app.py` module temporarily re-exports the imported names because
+existing models, routes, migrations, and tests still import from that module.
+Those compatibility exports will disappear as later Sprint 2 stories move the
+remaining code into the package.
 
 ## Consequences
 
 ### Positive
 
-- Establishes one supported import location.
-- Preserves the exact extension objects currently used by models and migrations.
-- Reduces risk and review size for the eventual definition move.
-- Allows model and blueprint extraction to begin using package imports.
+- SQLAlchemy models and migrations share one package-owned metadata registry.
+- Extension creation no longer occurs inside the route/model monolith.
+- Future blueprints and models have a stable import path.
+- Configuration remains authoritative before extension initialization.
+- Tests can verify that no duplicate security or persistence objects exist.
 
 ### Temporary limitations
 
-- Importing an extension still loads the legacy `app.py` module.
-- Extension definitions and initialization remain in the monolith.
-- Multiple independent application instances are not yet supported.
+- `app.py` still owns models, routes, helper functions, and scheduler setup.
+- The current factory still returns the transitional application singleton.
+- Multiple independent application instances remain a later factory goal.
 
-## Rejected alternative
+## Rejected alternatives
 
-Move every extension definition and all dependent model, migration, fixture,
-and route imports in one PR. This was rejected because it would combine several
-Sprint 2 stories and make behavior regressions harder to isolate.
+### Duplicate package and monolith instances
+
+Creating new extension objects in the package while leaving the original objects
+active in `app.py` was rejected because it would split SQLAlchemy metadata,
+migration discovery, authentication state, and CSRF handling.
+
+### Move extensions, models, and routes together
+
+A single large rewrite was rejected because it would combine multiple Sprint 2
+stories and make regressions difficult to isolate.
 
 ## Validation
 
-Tests verify that every object imported through `twitclone.extensions` is the
-same object exported by the current application module and that SQLAlchemy is
-registered with the configured Flask application.
+Tests verify that:
+
+- imports from `twitclone.extensions` and compatibility exports from `app.py`
+  reference the same objects;
+- SQLAlchemy remains registered with the configured application;
+- existing model metadata remains populated;
+- `app.py` no longer constructs Flask extension instances;
+- the login view remains unchanged.

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1,15 +1,17 @@
-"""Regression tests for the shared Flask extension import boundary."""
+"""Regression tests for package-owned Flask extension objects."""
+
+from pathlib import Path
 
 
 def test_shared_extension_imports_reference_active_objects():
     import app as legacy_app
-    from twitclone.extensions import bcrypt, csrf, db, login_manager, migrate
+    from twitclone import extensions
 
-    assert db is legacy_app.db
-    assert migrate is legacy_app.migrate
-    assert bcrypt is legacy_app.bcrypt
-    assert login_manager is legacy_app.login_manager
-    assert csrf is legacy_app.csrf
+    assert extensions.db is legacy_app.db
+    assert extensions.migrate is legacy_app.migrate
+    assert extensions.bcrypt is legacy_app.bcrypt
+    assert extensions.login_manager is legacy_app.login_manager
+    assert extensions.csrf is legacy_app.csrf
 
 
 def test_database_extension_is_registered_with_application():
@@ -21,9 +23,18 @@ def test_database_extension_is_registered_with_application():
     assert db.Model.metadata.tables
 
 
-def test_unknown_extension_name_fails_clearly():
-    import pytest
-    import twitclone.extensions as extensions
+def test_legacy_module_does_not_construct_extensions():
+    source = Path("app.py").read_text(encoding="utf-8")
 
-    with pytest.raises(AttributeError, match="has no attribute"):
-        getattr(extensions, "unknown_extension")
+    assert "SQLAlchemy(" not in source
+    assert "Migrate(" not in source
+    assert "Bcrypt(" not in source
+    assert "LoginManager(" not in source
+    assert "CSRFProtect(" not in source
+    assert "init_extensions(app)" in source
+
+
+def test_login_manager_keeps_existing_login_view():
+    from twitclone.extensions import login_manager
+
+    assert login_manager.login_view == "login"

--- a/twitclone/extensions.py
+++ b/twitclone/extensions.py
@@ -1,39 +1,36 @@
-"""Stable import boundary for TwitClone Flask extensions.
+"""Shared, application-independent Flask extension objects."""
 
-This module is the supported import location for shared Flask extension objects.
-During the incremental monolith refactor, the objects are still initialized by
-``app.py``. Later Sprint 2 work will move their definitions here without
-requiring models, migrations, tests, and routes to change imports again.
-"""
+from flask_bcrypt import Bcrypt
+from flask_login import LoginManager
+from flask_migrate import Migrate
+from flask_sqlalchemy import SQLAlchemy
+from flask_wtf import CSRFProtect
 
-from __future__ import annotations
+# Extensions are intentionally created without an application. The configured
+# application initializes them after configuration has been loaded and validated.
+db = SQLAlchemy()
+migrate = Migrate()
+bcrypt = Bcrypt()
+login_manager = LoginManager()
+login_manager.login_view = "login"
+csrf = CSRFProtect()
 
-from typing import Any
 
-_EXTENSION_NAMES = {
-    "db",
-    "migrate",
+def init_extensions(app) -> None:
+    """Bind all shared extensions to a configured Flask application."""
+
+    db.init_app(app)
+    migrate.init_app(app, db)
+    bcrypt.init_app(app)
+    login_manager.init_app(app)
+    csrf.init_app(app)
+
+
+__all__ = [
     "bcrypt",
-    "login_manager",
     "csrf",
-}
-
-
-def __getattr__(name: str) -> Any:
-    """Return the extension object currently owned by the legacy module."""
-
-    if name not in _EXTENSION_NAMES:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-    import app as legacy_app
-
-    return getattr(legacy_app, name)
-
-
-def __dir__() -> list[str]:
-    """Expose supported extension names to interactive tooling."""
-
-    return sorted(set(globals()) | _EXTENSION_NAMES)
-
-
-__all__ = sorted(_EXTENSION_NAMES)
+    "db",
+    "init_extensions",
+    "login_manager",
+    "migrate",
+]


### PR DESCRIPTION
## Sprint 2 Story 2.2 — completion slice

Completes Issue #46 by moving Flask extension ownership out of the legacy monolith and into `twitclone.extensions`.

## Changes

- Define unbound SQLAlchemy, Flask-Migrate, Bcrypt, Flask-Login, and CSRF objects in `twitclone/extensions.py`
- Add `init_extensions(app)` to bind shared objects after validated configuration is loaded
- Update `app.py` to import and initialize the package-owned objects
- Preserve temporary `app.py` compatibility exports for existing models, routes, migrations, and fixtures
- Keep the existing Flask-Login `login_view`
- Add regression tests proving `app.py` no longer constructs extension instances
- Update ADR-0007 with the completed ownership decision

## Security-tool merges

This branch starts from the latest `main` after the recently merged Renovate/Mend updates, including Flask-WTF 1.3.0 and updated transitive pins. No dependency versions are changed by this PR.

## Validation

```bash
python scripts/verify_dependencies.py
python scripts/verify_migrations.py
python -m pytest --strict-markers --maxfail=1
```

Focused validation:

```bash
python -m pytest tests/test_extensions.py
```

## Architecture outcome

New code can import stable package-owned objects:

```python
from twitclone.extensions import db, migrate, bcrypt, login_manager, csrf
```

There is one SQLAlchemy metadata registry and one instance of each security extension. Models and routes remain in `app.py` for later Sprint 2 stories.

## Scope control

No routes, models, templates, scheduler behavior, database schema, dependency versions, UI, Terraform, or AWS resources were changed.

Closes #46.