### PR TITLE
Sprint 2: Extract SQLAlchemy models into package

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,10 +1,10 @@
 from PIL import Image
 import os
 from flask import Flask, render_template, redirect, url_for, request, flash, jsonify, send_from_directory
-from flask_login import UserMixin, login_user, login_required, logout_user, current_user
+from flask_login import login_user, login_required, logout_user, current_user
 from werkzeug.utils import secure_filename
 import re
-from datetime import datetime, timedelta
+from datetime import datetime
 import hashlib
 from forms import PollForm
 from sqlalchemy import text
@@ -14,6 +14,19 @@ import atexit
 
 from config import Config
 from twitclone.extensions import bcrypt, csrf, db, init_extensions, login_manager, migrate
+from twitclone.models import (
+    Bookmark,
+    DirectMessage,
+    Follows,
+    Notification,
+    Poll,
+    PollOption,
+    PollVote,
+    Quote,
+    Retweet,
+    Tweet,
+    User,
+)
 
 
 Config.validate()
@@ -69,101 +82,6 @@ def get_trending_hashtags():
                 hashtags[tag] = 1
     sorted_hashtags = sorted(hashtags.items(), key=lambda x: x[1], reverse=True)
     return [tag for tag, count in sorted_hashtags[:5]]
-
-class Follows(db.Model):
-    follower_id = db.Column(db.Integer, db.ForeignKey('user.id'), primary_key=True)
-    followed_id = db.Column(db.Integer, db.ForeignKey('user.id'), primary_key=True)
-
-class User(db.Model, UserMixin):
-    id = db.Column(db.Integer, primary_key=True)
-    username = db.Column(db.String(150), nullable=False, unique=True)
-    email = db.Column(db.String(150), nullable=False, unique=True)
-    password = db.Column(db.String(150), nullable=False)
-    bio = db.Column(db.String(300))  # Add a bio field for user profile
-    followed = db.relationship('User', secondary='follows', 
-                               primaryjoin=(id == Follows.follower_id),
-                               secondaryjoin=(id == Follows.followed_id),
-                               backref=db.backref('followers', lazy='dynamic'), lazy='dynamic')
-    notifications = db.relationship('Notification', backref='user', lazy=True)
-    bookmarks = db.relationship('Bookmark', backref='bookmark_user', lazy=True)
-
-class Tweet(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
-    content = db.Column(db.String(144), nullable=False)
-    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
-    image = db.Column(db.String(100), nullable=True)
-    scheduled_at = db.Column(db.DateTime, nullable=True)
-    user = db.relationship('User', backref=db.backref('tweets', lazy=True))
-
-class Retweet(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
-    tweet_id = db.Column(db.Integer, db.ForeignKey('tweet.id'), nullable=False)
-    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
-    user = db.relationship('User', backref=db.backref('retweets', lazy=True))
-    tweet = db.relationship('Tweet', backref=db.backref('retweets', lazy=True))
-
-class Quote(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
-    tweet_id = db.Column(db.Integer, db.ForeignKey('tweet.id'), nullable=False)
-    content = db.Column(db.String(144), nullable=False)
-    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
-    user = db.relationship('User', backref=db.backref('quotes', lazy=True))
-    tweet = db.relationship('Tweet', backref=db.backref('quotes', lazy=True))
-
-class DirectMessage(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
-    content = db.Column(db.String(500), nullable=False)
-    sender_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
-    receiver_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
-    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
-    sender = db.relationship('User', foreign_keys=[sender_id], backref='sent_messages')
-    receiver = db.relationship('User', foreign_keys=[receiver_id], backref='received_messages')
-
-class Notification(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
-    message = db.Column(db.String(200), nullable=False)
-    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
-    read = db.Column(db.Boolean, default=False)
-
-class Bookmark(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
-    tweet_id = db.Column(db.Integer, db.ForeignKey('tweet.id'), nullable=False)
-    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
-    user = db.relationship('User', backref='bookmark_relationships')
-    tweet = db.relationship('Tweet', backref='bookmarked_tweets')
-
-class Poll(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
-    question = db.Column(db.String(255), nullable=False)
-    created_at = db.Column(db.DateTime, default=datetime.utcnow)
-    duration_days = db.Column(db.Integer, nullable=False)
-    duration_hours = db.Column(db.Integer, nullable=False)
-    duration_minutes = db.Column(db.Integer, nullable=False)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
-    user = db.relationship('User', backref=db.backref('polls', lazy=True))
-    options = db.relationship('PollOption', backref='poll', lazy=True)
-
-    @property
-    def is_active(self):
-        expiration_time = self.created_at + timedelta(days=self.duration_days, hours=self.duration_hours, minutes=self.duration_minutes)
-        return datetime.utcnow() < expiration_time
-
-class PollOption(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
-    option_text = db.Column(db.String(255), nullable=False)
-    poll_id = db.Column(db.Integer, db.ForeignKey('poll.id'), nullable=False)
-    votes = db.Column(db.Integer, default=0)
-
-class PollVote(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
-    poll_id = db.Column(db.Integer, db.ForeignKey('poll.id'), nullable=False)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
-    option_id = db.Column(db.Integer, db.ForeignKey('poll_option.id'), nullable=False)
 
 @login_manager.user_loader
 def load_user(user_id):

--- a/docs/architecture/ADR-0008-model-module.md
+++ b/docs/architecture/ADR-0008-model-module.md
@@ -1,0 +1,74 @@
+# ADR-0008: Move SQLAlchemy models into the application package
+
+- Status: Accepted
+- Date: 2026-07-25
+
+## Context
+
+TwitClone historically defined every SQLAlchemy model inside `app.py` alongside
+configuration, extension initialization, scheduler setup, helper functions, and
+routes. That structure made migrations and future blueprints depend on importing
+the entire legacy application module.
+
+ADR-0007 moved the shared Flask extension objects into `twitclone.extensions`.
+The next safe boundary is to move the model definitions onto that shared database
+registry before route extraction begins.
+
+## Decision
+
+All persistent domain models are defined in `twitclone/models.py` and import the
+shared `db` object from `twitclone.extensions`.
+
+The legacy `app.py` module temporarily imports and re-exports those model classes.
+This compatibility layer preserves existing route code, tests, migration loading,
+and any external imports while later Sprint 2 stories move routes into
+blueprints.
+
+No model redesign is included. Column definitions, inferred table names,
+relationships, backrefs, defaults, and model methods remain unchanged.
+
+New code should import models from:
+
+```python
+from twitclone.models import User, Tweet
+```
+
+## Consequences
+
+### Positive
+
+- Models no longer require importing the route monolith.
+- Migrations and future blueprints share one explicit metadata registry.
+- Route extraction can proceed without relocating model declarations at the same
+  time.
+- Model tests can validate schema metadata independently of route behavior.
+
+### Temporary limitations
+
+- `app.py` still imports and re-exports every model for compatibility.
+- The Flask-Login user loader remains registered in `app.py` until authentication
+  routes and lifecycle hooks are extracted.
+- Models remain in one module; splitting them by domain is intentionally deferred.
+
+## Schema compatibility
+
+This is a source-code relocation only. It must not produce a new Alembic
+revision. The existing migration remains authoritative and the table inventory
+must remain:
+
+- `user`, `follows`
+- `tweet`, `retweet`, `quote`
+- `direct_message`, `notification`
+- `bookmark`
+- `poll`, `poll_option`, `poll_vote`
+
+## Validation
+
+Regression tests verify:
+
+- `app.py` exports the exact package-owned classes
+- the complete table and column inventory
+- relationship registration
+- Flask-Login user loading
+- absence of model declarations in the legacy module
+- the existing migration can still initialize a clean database

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,111 @@
+"""Regression tests for the package-owned SQLAlchemy models."""
+
+import inspect
+
+
+EXPECTED_COLUMNS = {
+    "follows": {"follower_id", "followed_id"},
+    "user": {"id", "username", "email", "password", "bio"},
+    "tweet": {"id", "content", "timestamp", "user_id", "image", "scheduled_at"},
+    "retweet": {"id", "user_id", "tweet_id", "timestamp"},
+    "quote": {"id", "user_id", "tweet_id", "content", "timestamp"},
+    "direct_message": {"id", "content", "sender_id", "receiver_id", "timestamp"},
+    "notification": {"id", "user_id", "message", "timestamp", "read"},
+    "bookmark": {"id", "user_id", "tweet_id", "timestamp"},
+    "poll": {
+        "id",
+        "question",
+        "created_at",
+        "duration_days",
+        "duration_hours",
+        "duration_minutes",
+        "user_id",
+    },
+    "poll_option": {"id", "option_text", "poll_id", "votes"},
+    "poll_vote": {"id", "poll_id", "user_id", "option_id"},
+}
+
+
+def test_legacy_module_exports_package_model_classes():
+    import app as legacy_app
+    import twitclone.models as models
+
+    for model_name in models.__all__:
+        assert getattr(legacy_app, model_name) is getattr(models, model_name)
+
+
+def test_model_metadata_preserves_table_and_column_inventory():
+    from twitclone.extensions import db
+
+    assert set(db.metadata.tables) == set(EXPECTED_COLUMNS)
+
+    for table_name, expected_columns in EXPECTED_COLUMNS.items():
+        table = db.metadata.tables[table_name]
+        assert set(table.columns.keys()) == expected_columns
+
+
+def test_relationships_remain_registered():
+    from twitclone.models import Bookmark, DirectMessage, Poll, Quote, Retweet, Tweet, User
+
+    assert {relationship.key for relationship in User.__mapper__.relationships} == {
+        "followed",
+        "notifications",
+        "bookmarks",
+        "followers",
+        "tweets",
+        "retweets",
+        "quotes",
+        "sent_messages",
+        "received_messages",
+        "polls",
+        "bookmark_relationships",
+    }
+    assert {relationship.key for relationship in Tweet.__mapper__.relationships} == {
+        "user",
+        "retweets",
+        "quotes",
+        "bookmarked_tweets",
+    }
+    assert {relationship.key for relationship in Retweet.__mapper__.relationships} == {"user", "tweet"}
+    assert {relationship.key for relationship in Quote.__mapper__.relationships} == {"user", "tweet"}
+    assert {relationship.key for relationship in DirectMessage.__mapper__.relationships} == {"sender", "receiver"}
+    assert {relationship.key for relationship in Bookmark.__mapper__.relationships} == {"user", "tweet"}
+    assert {relationship.key for relationship in Poll.__mapper__.relationships} == {"user", "options"}
+
+
+def test_login_loader_returns_package_user(app):
+    import app as legacy_app
+    from twitclone.extensions import db
+    from twitclone.models import User
+
+    user = User(username="model-test", email="model-test@example.com", password="not-used")
+    with app.app_context():
+        db.session.add(user)
+        db.session.commit()
+        user_id = user.id
+
+        loaded_user = legacy_app.load_user(str(user_id))
+
+        assert loaded_user is not None
+        assert isinstance(loaded_user, User)
+        assert loaded_user.id == user_id
+
+
+def test_legacy_module_no_longer_declares_models():
+    import app as legacy_app
+
+    source = inspect.getsource(legacy_app)
+    for model_name in (
+        "Follows",
+        "User",
+        "Tweet",
+        "Retweet",
+        "Quote",
+        "DirectMessage",
+        "Notification",
+        "Bookmark",
+        "Poll",
+        "PollOption",
+        "PollVote",
+    ):
+        assert f"class {model_name}(" not in source

--- a/twitclone/models.py
+++ b/twitclone/models.py
@@ -1,0 +1,141 @@
+"""Database models for TwitClone.
+
+This module owns the application's SQLAlchemy model definitions. All models use
+the shared database extension from :mod:`twitclone.extensions` so migrations,
+routes, tests, and future blueprints operate on one metadata registry.
+"""
+
+from datetime import datetime, timedelta
+
+from flask_login import UserMixin
+
+from twitclone.extensions import db
+
+
+class Follows(db.Model):
+    follower_id = db.Column(db.Integer, db.ForeignKey('user.id'), primary_key=True)
+    followed_id = db.Column(db.Integer, db.ForeignKey('user.id'), primary_key=True)
+
+
+class User(db.Model, UserMixin):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(150), nullable=False, unique=True)
+    email = db.Column(db.String(150), nullable=False, unique=True)
+    password = db.Column(db.String(150), nullable=False)
+    bio = db.Column(db.String(300))
+    followed = db.relationship(
+        'User',
+        secondary='follows',
+        primaryjoin=(id == Follows.follower_id),
+        secondaryjoin=(id == Follows.followed_id),
+        backref=db.backref('followers', lazy='dynamic'),
+        lazy='dynamic',
+    )
+    notifications = db.relationship('Notification', backref='user', lazy=True)
+    bookmarks = db.relationship('Bookmark', backref='bookmark_user', lazy=True)
+
+
+class Tweet(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    content = db.Column(db.String(144), nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    image = db.Column(db.String(100), nullable=True)
+    scheduled_at = db.Column(db.DateTime, nullable=True)
+    user = db.relationship('User', backref=db.backref('tweets', lazy=True))
+
+
+class Retweet(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    tweet_id = db.Column(db.Integer, db.ForeignKey('tweet.id'), nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    user = db.relationship('User', backref=db.backref('retweets', lazy=True))
+    tweet = db.relationship('Tweet', backref=db.backref('retweets', lazy=True))
+
+
+class Quote(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    tweet_id = db.Column(db.Integer, db.ForeignKey('tweet.id'), nullable=False)
+    content = db.Column(db.String(144), nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    user = db.relationship('User', backref=db.backref('quotes', lazy=True))
+    tweet = db.relationship('Tweet', backref=db.backref('quotes', lazy=True))
+
+
+class DirectMessage(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    content = db.Column(db.String(500), nullable=False)
+    sender_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    receiver_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    sender = db.relationship('User', foreign_keys=[sender_id], backref='sent_messages')
+    receiver = db.relationship('User', foreign_keys=[receiver_id], backref='received_messages')
+
+
+class Notification(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    message = db.Column(db.String(200), nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    read = db.Column(db.Boolean, default=False)
+
+
+class Bookmark(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    tweet_id = db.Column(db.Integer, db.ForeignKey('tweet.id'), nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    user = db.relationship('User', backref='bookmark_relationships')
+    tweet = db.relationship('Tweet', backref='bookmarked_tweets')
+
+
+class Poll(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    question = db.Column(db.String(255), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    duration_days = db.Column(db.Integer, nullable=False)
+    duration_hours = db.Column(db.Integer, nullable=False)
+    duration_minutes = db.Column(db.Integer, nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    user = db.relationship('User', backref=db.backref('polls', lazy=True))
+    options = db.relationship('PollOption', backref='poll', lazy=True)
+
+    @property
+    def is_active(self):
+        expiration_time = self.created_at + timedelta(
+            days=self.duration_days,
+            hours=self.duration_hours,
+            minutes=self.duration_minutes,
+        )
+        return datetime.utcnow() < expiration_time
+
+
+class PollOption(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    option_text = db.Column(db.String(255), nullable=False)
+    poll_id = db.Column(db.Integer, db.ForeignKey('poll.id'), nullable=False)
+    votes = db.Column(db.Integer, default=0)
+
+
+class PollVote(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    poll_id = db.Column(db.Integer, db.ForeignKey('poll.id'), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    option_id = db.Column(db.Integer, db.ForeignKey('poll_option.id'), nullable=False)
+
+
+__all__ = [
+    'Bookmark',
+    'DirectMessage',
+    'Follows',
+    'Notification',
+    'Poll',
+    'PollOption',
+    'PollVote',
+    'Quote',
+    'Retweet',
+    'Tweet',
+    'User',
+]


### PR DESCRIPTION
## Sprint 2 Story 2.3

Moves all SQLAlchemy model definitions out of the legacy `app.py` monolith and into `twitclone/models.py` without changing the database schema or user-facing behavior.

## Changes

- Add `twitclone/models.py` using the shared `twitclone.extensions.db`
- Move all 11 existing model classes into the package
- Preserve every column, inferred table name, relationship, backref, default, and model method
- Update `app.py` to import and temporarily re-export the package-owned classes
- Preserve the existing Flask-Login user loader
- Add model identity, table/column inventory, relationship, login-loader, and source-boundary tests
- Add ADR-0008 documenting model ownership and compatibility boundaries

## Schema safety

This is a source relocation only. No migration revision is added, and the existing migration remains authoritative. CI must confirm the same table inventory:

- `user`, `follows`
- `tweet`, `retweet`, `quote`
- `direct_message`, `notification`
- `bookmark`
- `poll`, `poll_option`, `poll_vote`

## Validation

```bash
python scripts/verify_dependencies.py
python scripts/verify_migrations.py
python -m pytest --strict-markers --maxfail=1
```

Focused validation:

```bash
python -m pytest tests/test_models.py
```

## Security-tool baseline

The branch starts after the latest Snyk, Dependabot, and Renovate merges and after PR #59 restored Python 3.12 alignment. No dependency or workflow versions are changed here.

## Scope control

No routes, templates, scheduler behavior, database schema, dependencies, UI, Terraform, or AWS resources were changed.

Closes #60.