### PR TITLE
Sprint 2: Extract reusable utilities into package

### DIFF
--- a/docs/architecture/ADR-0009-package-owned-utilities.md
+++ b/docs/architecture/ADR-0009-package-owned-utilities.md
@@ -1,0 +1,46 @@
+# ADR-0009: Package-owned utility boundary
+
+- Status: Accepted
+- Date: 2026-07-28
+- Sprint: 2
+- Story: 2.4
+
+## Context
+
+Reusable Gravatar, image, hashtag, user-discovery, and text-formatting helpers were defined inside the legacy `app.py` monolith. Blueprint extraction would otherwise require new package modules to import that monolith, preserving circular ownership and import-time side effects.
+
+A complete physical rewrite of `app.py` solely to delete small helper definitions would create a large, difficult-to-review file replacement while route extraction is already planned in subsequent stories.
+
+## Decision
+
+Create a package-owned `twitclone.utils` boundary with focused modules:
+
+- `gravatar.py` for Gravatar URLs
+- `images.py` for thumbnail generation
+- `hashtags.py` for trending hashtags and newest-user queries
+- `text.py` for clickable mentions and hashtags
+
+The supported `twitclone.create_app()` path explicitly binds the transitional legacy module's helper names to these package implementations after importing `app.py`. Existing routes, context processors, and template filters resolve those names at request time, so behavior and endpoint registration remain unchanged.
+
+The original helper definitions may remain as dormant compatibility code until their related route groups move into blueprints. Package utilities are authoritative for the supported runtime and for all new code.
+
+## Consequences
+
+### Positive
+
+- New blueprints can import helpers without importing `app.py`.
+- Pure helpers can be unit tested independently.
+- Database-backed discovery helpers depend on package-owned models rather than the monolith.
+- The refactor avoids route, schema, template, and endpoint changes.
+- Future blueprint PRs can delete legacy copies alongside the code that used them.
+
+### Negative
+
+- Direct unsupported execution or import of `app.py` before factory binding can still expose the legacy helper definitions.
+- There is temporary source duplication until blueprint extraction removes the dormant copies.
+
+## Guardrails
+
+- New code imports utilities only from `twitclone.utils` or its submodules.
+- Behavioral changes to hashtag ranking, image sizing, generated markup, or Gravatar formatting require separate stories.
+- The compatibility binder is removed only after no supported route or template callback depends on legacy globals.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,79 @@
+"""Regression tests for package-owned utility behavior."""
+
+from __future__ import annotations
+
+import hashlib
+
+from PIL import Image
+
+import app as legacy_app
+from twitclone.extensions import db
+from twitclone.models import Tweet, User
+from twitclone.utils import (
+    get_newest_users,
+    get_trending_hashtags,
+    gravatar,
+    make_clickable_links,
+    resize_image,
+)
+
+
+def test_gravatar_preserves_existing_url_format():
+    email = "Example@Email.com"
+    digest = hashlib.md5(email.lower().encode("utf-8")).hexdigest()
+
+    assert gravatar(email) == (
+        f"https://www.gravatar.com/avatar/{digest}?s=100&d=identicon&r=g"
+    )
+    assert gravatar(email, size=48, default="retro", rating="pg") == (
+        f"https://www.gravatar.com/avatar/{digest}?s=48&d=retro&r=pg"
+    )
+
+
+def test_make_clickable_links_preserves_existing_markup():
+    assert make_clickable_links("Hello @mallard from #UpstateNY") == (
+        'Hello <a href="/profile/mallard">@mallard</a> from '
+        '<a href="/hashtag/UpstateNY">#UpstateNY</a>'
+    )
+
+
+def test_resize_image_preserves_aspect_ratio_and_default_bounds(tmp_path):
+    source = tmp_path / "source.png"
+    output = tmp_path / "output.png"
+    Image.new("RGB", (400, 100)).save(source)
+
+    resize_image(source, output)
+
+    with Image.open(output) as resized:
+        assert resized.size == (200, 50)
+
+
+def test_newest_users_and_trending_hashtags_preserve_query_behavior(app):
+    with app.app_context():
+        first = User(username="first", email="first@example.com", password="hash")
+        second = User(username="second", email="second@example.com", password="hash")
+        third = User(username="third", email="third@example.com", password="hash")
+        db.session.add_all([first, second, third])
+        db.session.flush()
+        db.session.add_all(
+            [
+                Tweet(content="#rv #travel", user_id=first.id),
+                Tweet(content="#rv #camping", user_id=second.id),
+                Tweet(content="#rv #travel", user_id=third.id),
+            ]
+        )
+        db.session.commit()
+
+        assert [user.username for user in get_newest_users(limit=2)] == [
+            "third",
+            "second",
+        ]
+        assert get_trending_hashtags() == ["rv", "travel", "camping"]
+
+
+def test_supported_runtime_binds_legacy_names_to_package_utilities():
+    assert legacy_app.gravatar is gravatar
+    assert legacy_app.get_newest_users is get_newest_users
+    assert legacy_app.get_trending_hashtags is get_trending_hashtags
+    assert legacy_app.resize_image is resize_image
+    assert legacy_app.make_clickable_links is make_clickable_links

--- a/twitclone/__init__.py
+++ b/twitclone/__init__.py
@@ -1,8 +1,8 @@
 """TwitClone application factory.
 
-This factory provides one supported construction path while the existing routes,
-models, and extensions remain in the legacy ``app.py`` module. Later Sprint 2
-stories will move those responsibilities into this package incrementally.
+This factory provides one supported construction path while the existing routes
+remain in the legacy ``app.py`` module. Later Sprint 2 stories will move those
+responsibilities into this package incrementally.
 """
 
 from __future__ import annotations
@@ -17,17 +17,23 @@ from config import Config
 def create_app(config_object: type[Config] = Config) -> Flask:
     """Create and configure the TwitClone Flask application.
 
-    The legacy module still owns route and model registration. Importing it only
-    after configuration validation ensures the supported startup path fails
-    before serving requests when required environment values are missing.
+    The legacy module still owns route registration. Importing it only after
+    configuration validation ensures the supported startup path fails before
+    serving requests when required environment values are missing.
     """
 
     config_object.validate()
 
     # Imported lazily so callers can establish environment variables before the
     # legacy module and its Flask extensions are loaded.
-    from app import app as flask_app
-    from app import scheduler
+    import app as legacy_app
+
+    from twitclone.utils import bind_legacy_module
+
+    bind_legacy_module(legacy_app)
+
+    flask_app = legacy_app.app
+    scheduler = legacy_app.scheduler
 
     flask_app.config.from_object(config_object)
     Path(flask_app.config["UPLOAD_FOLDER"]).mkdir(parents=True, exist_ok=True)

--- a/twitclone/utils/__init__.py
+++ b/twitclone/utils/__init__.py
@@ -1,0 +1,34 @@
+"""Package-owned utility boundary and legacy compatibility binding."""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+from twitclone.utils.gravatar import gravatar
+from twitclone.utils.hashtags import get_newest_users, get_trending_hashtags
+from twitclone.utils.images import resize_image
+from twitclone.utils.text import make_clickable_links
+
+
+def bind_legacy_module(module: ModuleType) -> None:
+    """Point the transitional legacy module at package-owned helpers.
+
+    Routes and template callbacks resolve these names at request time, so rebinding
+    preserves their public endpoints while making the package implementations
+    authoritative on the supported application-factory path.
+    """
+    module.gravatar = gravatar
+    module.get_newest_users = get_newest_users
+    module.get_trending_hashtags = get_trending_hashtags
+    module.resize_image = resize_image
+    module.make_clickable_links = make_clickable_links
+
+
+__all__ = [
+    "bind_legacy_module",
+    "get_newest_users",
+    "get_trending_hashtags",
+    "gravatar",
+    "make_clickable_links",
+    "resize_image",
+]

--- a/twitclone/utils/gravatar.py
+++ b/twitclone/utils/gravatar.py
@@ -1,0 +1,11 @@
+"""Gravatar URL helpers."""
+
+from __future__ import annotations
+
+import hashlib
+
+
+def gravatar(email: str, size: int = 100, default: str = "identicon", rating: str = "g") -> str:
+    """Return the Gravatar URL used by existing templates."""
+    digest = hashlib.md5(email.lower().encode("utf-8")).hexdigest()
+    return f"https://www.gravatar.com/avatar/{digest}?s={size}&d={default}&r={rating}"

--- a/twitclone/utils/hashtags.py
+++ b/twitclone/utils/hashtags.py
@@ -1,0 +1,23 @@
+"""Timeline discovery helpers backed by package-owned models."""
+
+from __future__ import annotations
+
+import re
+
+from twitclone.models import Tweet, User
+
+
+def get_newest_users(limit: int = 5):
+    """Return the newest users using the existing descending-id ordering."""
+    return User.query.order_by(User.id.desc()).limit(limit).all()
+
+
+def get_trending_hashtags(limit: int = 5) -> list[str]:
+    """Return hashtag names ordered by descending occurrence count."""
+    hashtags: dict[str, int] = {}
+    for tweet in Tweet.query.all():
+        for tag in re.findall(r"#(\w+)", tweet.content):
+            hashtags[tag] = hashtags.get(tag, 0) + 1
+
+    sorted_hashtags = sorted(hashtags.items(), key=lambda item: item[1], reverse=True)
+    return [tag for tag, _count in sorted_hashtags[:limit]]

--- a/twitclone/utils/images.py
+++ b/twitclone/utils/images.py
@@ -1,0 +1,18 @@
+"""Image processing helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from PIL import Image
+
+
+def resize_image(
+    image_path: str | Path,
+    output_path: str | Path,
+    size: tuple[int, int] = (200, 200),
+) -> None:
+    """Create a thumbnail using the existing aspect-preserving behavior."""
+    with Image.open(image_path) as image:
+        image.thumbnail(size)
+        image.save(output_path)

--- a/twitclone/utils/text.py
+++ b/twitclone/utils/text.py
@@ -1,0 +1,11 @@
+"""Text formatting helpers."""
+
+from __future__ import annotations
+
+import re
+
+
+def make_clickable_links(text: str) -> str:
+    """Convert @mentions and #hashtags to the existing profile/hashtag links."""
+    text = re.sub(r"@(\w+)", r'<a href="/profile/\1">@\1</a>', text)
+    return re.sub(r"#(\w+)", r'<a href="/hashtag/\1">#\1</a>', text)


### PR DESCRIPTION
## Sprint 2 Story 2.4

Introduces package-owned utility modules for reusable helper behavior while preserving every existing route, endpoint, template callback, database query result, and user-visible output.

## Changes

- Add `twitclone/utils/` with focused Gravatar, image, discovery, and text modules
- Preserve the existing Gravatar URL format and defaults
- Preserve aspect-ratio thumbnail behavior and the `(200, 200)` default bound
- Preserve newest-user descending-ID ordering
- Preserve hashtag parsing, occurrence counting, tie behavior, and five-item default limit
- Preserve clickable `@mention` and `#hashtag` markup
- Update `twitclone.create_app()` to bind the supported runtime to package-owned helpers
- Add unit and integration regression tests
- Add ADR-0009 documenting the transitional compatibility boundary

## Transitional compatibility

This PR intentionally does not replace the entire legacy `app.py` file merely to delete five small definitions. Existing callbacks resolve helper names at request time, and the supported factory explicitly rebinds those names to package implementations. The dormant legacy copies will be deleted with their related route groups during blueprint extraction.

New code must import from `twitclone.utils`; it no longer needs to import the monolith.

## Validation

CI should run:

```bash
python scripts/verify_dependencies.py
python scripts/verify_migrations.py
python -m pytest --strict-markers --maxfail=1
```

Focused validation:

```bash
python -m pytest tests/test_utils.py
```

## Security-tool baseline

The branch starts at current `main` after PR #61 and the subsequent Renovate `pytz` update. No dependency or workflow version is changed here.

## Scope control

No route, endpoint, template, model, migration, scheduler behavior, dependency, UI, Terraform, or AWS resource is changed.

Closes #63.